### PR TITLE
Fix build entry resolution by updating manifest paths and Vite config

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     "default_title": "Crocro"
   },
   "background": {
-    "service_worker": "background.js",
+    "service_worker": "background/index.ts",
     "type": "module"
   },
   "permissions": ["storage", "scripting"],
@@ -17,7 +17,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["content.js"],
+      "js": ["content/index.ts"],
       "run_at": "document_idle"
     }
   ],

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -26,11 +26,11 @@ function connect() {
 
 connect();
 
-browser.runtime.onMessage.addListener(async (msg: { type: string; payload?: any; from?: string; id?: string }) => {
+browser.runtime.onMessage.addListener(async (msg: { type: string; payload?: Parameters<typeof putMessage>[0]; from?: string; id?: string }) => {
   switch (msg.type) {
     case 'send-message':
       ws?.send(JSON.stringify({ type: 'message', payload: msg.payload }));
-      await putMessage(msg.payload);
+      await putMessage(msg.payload!);
       break;
     case 'typing':
       ws?.send(JSON.stringify({ type: 'typing', from: msg.from }));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import webExtension from '@samrum/vite-plugin-web-extension';
 import manifest from './manifest.json';
 
 export default defineConfig(({ mode }) => ({
+  root: 'src',
   plugins: [
     react(),
     webExtension({
@@ -12,7 +13,7 @@ export default defineConfig(({ mode }) => ({
     })
   ],
   build: {
-    outDir: 'dist',
+    outDir: '../dist',
     emptyOutDir: true
   }
 }));


### PR DESCRIPTION
## Summary
- point manifest background and content scripts to TypeScript sources
- set Vite root to `src` and output to `dist` for proper entry resolution
- type background message payload to satisfy linting

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ac4129c44c832283294564b1524438